### PR TITLE
Don't leak information about existing user data in production

### DIFF
--- a/lib/RestWrite.js
+++ b/lib/RestWrite.js
@@ -33,6 +33,16 @@ var triggers = require('./triggers');
 var ClientSDK = require('./ClientSDK');
 
 
+function obfuscateError() {
+  throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, "Bad Request");
+}
+
+function obfuscateErrorWhenProd() {
+  if (process.env.PROD_CLOUD == 0) {
+    obfuscateError();
+  }
+}
+
 // query and data are both provided in REST API format. So data
 // types are encoded by plain old objects.
 // If query is null, this is a "create" and the data in data should be
@@ -292,6 +302,7 @@ RestWrite.prototype.handleAuthData = function (authData) {
       return !this.auth.isMaster && user.ACL && Object.keys(user.ACL).length > 0;
     });
     if (results.length > 1) {
+      obfuscateErrorWhenProd();
       // More than 1 user with the passed id's
       throw new Parse.Error(Parse.Error.ACCOUNT_ALREADY_LINKED, 'this auth is already used');
     }
@@ -359,6 +370,7 @@ RestWrite.prototype.handleAuthData = function (authData) {
         // Trying to update auth data but users
         // are different
         if (userResult.objectId !== userId) {
+          obfuscateErrorWhenProd();
           throw new Parse.Error(Parse.Error.ACCOUNT_ALREADY_LINKED, 'this auth is already used');
         }
         // No auth data was mutated, just keep going
@@ -380,6 +392,7 @@ RestWrite.prototype.transformUser = function () {
   }
 
   if (!this.auth.isMaster && "emailVerified" in this.data) {
+    obfuscateErrorWhenProd();
     const error = `Clients aren't allowed to manually update email verification.`;
     throw new Parse.Error(Parse.Error.OPERATION_FORBIDDEN, error);
   }
@@ -440,6 +453,7 @@ RestWrite.prototype._validateUserName = function () {
   // TODO: Check if there is a unique index, and if so, skip this query.
   return this.config.database.find(this.className, { username: this.data.username, objectId: { '$ne': this.objectId() } }, { limit: 1 }).then(results => {
     if (results.length > 0) {
+      obfuscateErrorWhenProd();
       throw new Parse.Error(Parse.Error.USERNAME_TAKEN, 'Account already exists for this username.');
     }
     return;
@@ -457,6 +471,7 @@ RestWrite.prototype._validateEmail = function () {
   // Same problem for email as above for username
   return this.config.database.find(this.className, { email: this.data.email, objectId: { '$ne': this.objectId() } }, { limit: 1 }).then(results => {
     if (results.length > 0) {
+      obfuscateErrorWhenProd();
       throw new Parse.Error(Parse.Error.EMAIL_TAKEN, 'Account already exists for this email address.');
     }
     if (!this.data.authData || !Object.keys(this.data.authData).length || Object.keys(this.data.authData).length === 1 && Object.keys(this.data.authData)[0] === 'anonymous') {
@@ -1000,10 +1015,12 @@ RestWrite.prototype.runDatabaseOperation = function () {
 
       // Quick check, if we were able to infer the duplicated field name
       if (error && error.userInfo && error.userInfo.duplicated_field === 'username') {
+        obfuscateErrorWhenProd();
         throw new Parse.Error(Parse.Error.USERNAME_TAKEN, 'Account already exists for this username.');
       }
 
       if (error && error.userInfo && error.userInfo.duplicated_field === 'email') {
+        obfuscateErrorWhenProd();
         throw new Parse.Error(Parse.Error.EMAIL_TAKEN, 'Account already exists for this email address.');
       }
 
@@ -1013,11 +1030,13 @@ RestWrite.prototype.runDatabaseOperation = function () {
       // TODO: See if we can later do this without additional queries by using named indexes.
       return this.config.database.find(this.className, { username: this.data.username, objectId: { '$ne': this.objectId() } }, { limit: 1 }).then(results => {
         if (results.length > 0) {
+          obfuscateErrorWhenProd();
           throw new Parse.Error(Parse.Error.USERNAME_TAKEN, 'Account already exists for this username.');
         }
         return this.config.database.find(this.className, { email: this.data.email, objectId: { '$ne': this.objectId() } }, { limit: 1 });
       }).then(results => {
         if (results.length > 0) {
+          obfuscateErrorWhenProd();
           throw new Parse.Error(Parse.Error.EMAIL_TAKEN, 'Account already exists for this email address.');
         }
         throw new Parse.Error(Parse.Error.DUPLICATE_VALUE, 'A duplicate value for a field with unique values was provided');


### PR DESCRIPTION
- If we're in a production environment, return "Bad Request" instead
  of more helpful error messages that could leak information about
  user accounts